### PR TITLE
Implement initial Metiseon MVP skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: environment.yml
-          environment-name: metiseon
+          activate-environment: metiseon
           auto-activate-base: false
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          environment-file: environment.yml
+          environment-name: metiseon
+          auto-activate-base: false
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest -q

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,19 @@
+name: Weekly Trade
+
+on:
+  schedule:
+    - cron: '15 6 * * 5'
+
+jobs:
+  trade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          environment-file: environment.yml
+          environment-name: metiseon
+          auto-activate-base: false
+      - name: Execute trade
+        shell: bash -l {0}
+        run: python run.py trade --budget 100

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: environment.yml
-          environment-name: metiseon
+          activate-environment: metiseon
           auto-activate-base: false
       - name: Execute trade
         shell: bash -l {0}

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,8 @@
+tickers: [VTI, IEFA, GLD, VNQ, BND, BTC-USD]
+weekly_buy: 100
+risk_window: 63
+sigma_method: garch
+slip_cap_bp: 35
+report_path: reports/latest.html
+db_path: portfolio.db
+currency: CHF

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,11 @@ dependencies:
   - pandas>=2.2
   - numpy
   - yfinance>=0.2
-  - alpha_vantage
-  - fredapi
   - matplotlib
   - arch
   - requests-cache
   - pytest
+  - pip
+  - pip:
+      - alpha_vantage
+      - fredapi

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,12 @@ dependencies:
   - duckdb>=0.10
   - pandas>=2.2
   - numpy
-  - yfinance>=0.2
   - matplotlib
-  - arch
   - requests-cache
   - pytest
   - pip
   - pip:
+      - yfinance>=0.2
+      - arch
       - alpha_vantage
       - fredapi

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: metiseon
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - duckdb>=0.10
+  - pandas>=2.2
+  - numpy
+  - yfinance>=0.2
+  - alpha_vantage
+  - fredapi
+  - matplotlib
+  - arch
+  - requests-cache
+  - pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import yaml
+
+
+def load_config(path: str) -> dict:
+    with open(path, "r") as fh:
+        return yaml.safe_load(fh)
+
+
+def cmd_backtest(args: argparse.Namespace) -> None:
+    cfg = load_config(args.config)
+    print(f"Backtest {args.start} -> {args.end} for {cfg['tickers']}")
+
+
+def cmd_trade(args: argparse.Namespace) -> None:
+    cfg = load_config(args.config)
+    cash = args.budget if args.budget is not None else f"{args.pct * 100}% NAV"
+    print(f"Trade {cash} for tickers {cfg['tickers']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config.yml")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    b = sub.add_parser("backtest")
+    b.add_argument("--start", required=True)
+    b.add_argument("--end", required=True)
+    b.set_defaults(func=cmd_backtest)
+
+    t = sub.add_parser("trade")
+    t.add_argument("--budget", type=float)
+    t.add_argument("--pct", type=float)
+    t.set_defaults(func=cmd_trade)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/allocator.py
+++ b/src/allocator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+
+import pandas as pd
+
+
+def select_asset(scores: pd.Series, sigma: pd.Series, last_winner: str | None = None) -> str | None:
+    """Return ticker with highest score passing risk filter."""
+    candidates = scores.index
+    if last_winner in candidates:
+        candidates = candidates.drop(last_winner)
+    risk_gate = sigma.loc[candidates] <= sigma.median()
+    filtered = scores.loc[candidates][risk_gate]
+    if filtered.empty:
+        return None
+    max_score = filtered.max()
+    best = filtered[filtered == max_score]
+    if len(best) > 1:
+        sig_sub = sigma[best.index]
+        return sig_sub.idxmin()
+    return best.idxmax()
+
+
+def order_quantity(price: float, cash: float) -> Decimal:
+    q = Decimal(cash) / Decimal(price)
+    return q.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+
+
+def slippage_bp(quantity: Decimal, adv10: float) -> float:
+    if adv10 <= 0:
+        return 0.0
+    slip_decimal = 0.001 * ((float(quantity) / adv10) ** 0.5)
+    return slip_decimal * 10000
+
+
+def should_trade(fee_bp: float, slip_bp: float, cap_bp: float) -> bool:
+    return fee_bp + slip_bp <= cap_bp

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+from typing import Iterable
+
+import pandas as pd
+import requests_cache
+import yfinance as yf
+from alpha_vantage.fundamentaldata import FundamentalData
+from fredapi import Fred
+
+
+CACHE_NAME = "metiseon_cache"
+
+
+def init_cache(expire_after: int = 86400) -> None:
+    requests_cache.install_cache(CACHE_NAME, expire_after=expire_after)
+
+
+async def _fetch_yf(ticker: str, start: str, end: str) -> pd.DataFrame:
+    return yf.download(ticker, start=start, end=end, progress=False)
+
+
+async def prices(tickers: Iterable[str], start: str, end: str) -> dict[str, pd.DataFrame]:
+    loop = asyncio.get_event_loop()
+    tasks = [loop.run_in_executor(None, partial(yf.download, t, start=start, end=end, progress=False)) for t in tickers]
+    data = await asyncio.gather(*tasks)
+    return dict(zip(tickers, data))
+
+
+def fundamentals(ticker: str, api_key: str) -> pd.DataFrame:
+    fd = FundamentalData(key=api_key)
+    data, _ = fd.get_company_overview(symbol=ticker)
+    return pd.DataFrame([data])
+
+
+def benchmarks(series: str, start: str, end: str, api_key: str) -> pd.Series:
+    fred = Fred(api_key=api_key)
+    data = fred.get_series(series, observation_start=start, observation_end=end)
+    return data

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import duckdb
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS trades (
+    ts TIMESTAMP,
+    ticker TEXT,
+    qty DOUBLE,
+    price DOUBLE,
+    fee DOUBLE,
+    PRIMARY KEY (ts, ticker)
+);
+
+CREATE TABLE IF NOT EXISTS positions (
+    ts TIMESTAMP,
+    ticker TEXT,
+    qty DOUBLE,
+    cost_basis DOUBLE,
+    nav DOUBLE
+);
+"""
+
+
+def connect(path: str) -> duckdb.DuckDBPyConnection:
+    conn = duckdb.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(SCHEMA_SQL)
+    return conn

--- a/src/risk.py
+++ b/src/risk.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from arch import arch_model
+
+
+def garch_volatility(prices: pd.Series) -> pd.Series:
+    """Return conditional volatility from a simple GARCH(1,1) model."""
+    returns = np.log(prices / prices.shift(1)).dropna() * 100
+    if len(returns) < 10:
+        return pd.Series(dtype=float)
+    am = arch_model(returns, p=1, q=1)
+    res = am.fit(disp="off")
+    vol = res.conditional_volatility / 100
+    vol.index = prices.index[1:]
+    return vol
+
+
+def rolling_std(prices: pd.Series, window: int) -> pd.Series:
+    returns = np.log(prices / prices.shift(1))
+    return returns.rolling(window).std().dropna()
+
+
+def fx_beta(asset_returns: pd.Series, fx_returns: pd.Series) -> float:
+    common = pd.concat([asset_returns, fx_returns], axis=1).dropna()
+    if common.empty:
+        return 0.0
+    cov = common.iloc[:, 0].cov(common.iloc[:, 1])
+    var = common.iloc[:, 1].var()
+    return 0.0 if var == 0 else cov / var
+
+
+def cvar(returns: pd.Series, level: float = 0.95) -> float:
+    if returns.empty:
+        return 0.0
+    cutoff = returns.quantile(1 - level)
+    tail = returns[returns <= cutoff]
+    return tail.mean()

--- a/src/score.py
+++ b/src/score.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def durability_score(row: pd.Series) -> float:
+    """Compute Durability-Lite score for a single asset.
+
+    Parameters
+    ----------
+    row : pd.Series
+        Must contain columns: 'roe', 'debt_equity', 'profit_margin',
+        'insider_own', 'rd_to_rev'.
+
+    Returns
+    -------
+    float
+        Score clamped to [0, 100].
+    """
+    score = 25
+    if row.get("roe", 0) > 0.12:
+        score += 20
+    if row.get("debt_equity", float("inf")) < 1:
+        score += 15
+    if row.get("profit_margin", 0) > 0.10:
+        score += 15
+    if row.get("insider_own", 0) > 0.02:
+        score += 10
+    if row.get("rd_to_rev", 0) > 0.05:
+        score += 15
+    if row.get("debt_equity", 0) > 1 and row.get("insider_own", 1) < 0.01:
+        score -= 10
+    return max(0.0, min(100.0, score))
+
+
+def apply_scores(df: pd.DataFrame) -> pd.Series:
+    """Return Durability scores for all rows."""
+    return df.apply(durability_score, axis=1)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from decimal import Decimal
+
+from src.score import durability_score
+from src.allocator import order_quantity, slippage_bp, should_trade
+from src.risk import cvar
+
+
+def test_durability_score():
+    row = pd.Series(
+        {
+            "roe": 0.15,
+            "debt_equity": 0.5,
+            "profit_margin": 0.2,
+            "insider_own": 0.03,
+            "rd_to_rev": 0.06,
+        }
+    )
+    assert durability_score(row) == 100
+
+
+def test_order_and_slippage():
+    q = order_quantity(10, 105)
+    slip = slippage_bp(q, adv10=1000)
+    assert q == Decimal("10.5000")
+    assert slip > 0
+    assert should_trade(12, slip, 35)
+
+
+def test_cvar():
+    returns = pd.Series([-0.1, 0.02, 0.03, -0.05, 0.01])
+    val = cvar(returns)
+    assert val < 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pandas as pd
 from decimal import Decimal
 


### PR DESCRIPTION
## Summary
- add project dependencies via `environment.yml`
- implement CLI entry in `run.py`
- create async data loaders, scoring, risk and allocator modules
- provide simple DuckDB helper
- configure CI workflow and weekly trade cron job
- add basic unit tests
- supply default `config.yml`

## Testing
- `pip install pandas numpy yfinance alpha_vantage fredapi matplotlib arch requests-cache pytest >/tmp/pip.log`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dcffec38832899fa7d999fc6f51e