### PR TITLE
Implement ADV slippage

### DIFF
--- a/src/slippage.py
+++ b/src/slippage.py
@@ -1,0 +1,31 @@
+"""Slippage and trading cost helpers."""
+
+from __future__ import annotations
+
+import math
+
+
+def adv_slip_bps(order_notional: float, adv: float) -> float:
+    """Return market impact from order size and ADV.
+
+    Parameters
+    ----------
+    order_notional : float
+        Notional value of the order.
+    adv : float
+        Average daily traded value (ADV) for the asset.
+
+    Returns
+    -------
+    float
+        Estimated slippage expressed as a decimal fraction where ``0.01``
+        corresponds to 1 % (100 bps).  The model applies a square‐root
+        volume impact ``0.001 * sqrt(order_notional / adv)`` and enforces
+        a 10 bps minimum.
+    """
+
+    if order_notional <= 0 or adv <= 0:
+        return 0.001
+
+    slip = 0.001 * math.sqrt(order_notional / adv)
+    return max(slip, 0.001)


### PR DESCRIPTION
## Summary
- add new `slippage.py` module
- implement `adv_slip_bps` helper with volume-root impact and 10 bps floor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fd6c90748328858b926c8866b951