### PR TITLE
Integrate MEΩ numeraire helpers

### DIFF
--- a/src/risk.py
+++ b/src/risk.py
@@ -34,7 +34,7 @@ def garch_sigma(prices: pd.Series, denom_series: pd.Series) -> pd.Series:
     try:
         res = model.fit(disp="off")
     except Exception:
-        return pd.Series(index=log_ret.index, dtype=float)
+        return pd.Series(index=prices.index, dtype=float)
 
     sigma = pd.Series(res.conditional_volatility / scale, index=r.index)
     return sigma.reindex(prices.index)

--- a/tests/test_meo_weights.py
+++ b/tests/test_meo_weights.py
@@ -26,3 +26,9 @@ def test_meo_weights(monkeypatch):
     df, m_world = meo.fetch_meo_components(date(2024, 1, 1))
     assert abs(df["weight"].sum() - 1) < 1e-9
     assert meo.meo_price_usd(m_world) == m_world * 1e-6
+
+
+def test_cross_price():
+    result = meo.meo_cross_price(10.0, 2.0)
+    assert result == 5.0
+    assert pd.isna(meo.meo_cross_price(10.0, 0.0))


### PR DESCRIPTION
## Summary
- fix return index when GARCH fitting fails
- add unit test for `meo_cross_price`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d708ece083289e498311cc3b992c